### PR TITLE
Remove unnecessary authentication from endpoints

### DIFF
--- a/routes/athletics-schedule.js
+++ b/routes/athletics-schedule.js
@@ -78,7 +78,8 @@ routeAthleticsSchedule.ENDPOINT = {
     getter: routeAthleticsSchedule.getAthleticsSchedule,
     location: "http://athletics.gordon.edu/calendar.ashx/calendar.rss",
     processor: routeAthleticsSchedule.parseAthleticsSchedule,
-    cache: "global"
+    cache: "global",
+    method: "get"
 };
 
 routeAthleticsSchedule.endpoint = (app) => {

--- a/routes/days-left-in-semester.js
+++ b/routes/days-left-in-semester.js
@@ -26,7 +26,8 @@ routeDaysLeftInSemester.ENDPOINT = {
     getter: db.get,
     location: "info",
     processor: routeDaysLeftInSemester.getDaysLeftInSemester,
-    cache: false
+    cache: false,
+    method: "get"
 };
 
 routeDaysLeftInSemester.endpoint = (app) => {

--- a/routes/highland-express.js
+++ b/routes/highland-express.js
@@ -31,7 +31,8 @@ routeHighlandExpress.ENDPOINT = {
     getter: db.get,
     location: "highlandexpress",
     processor: routeHighlandExpress.processHighlandExpress,
-    cache: false
+    cache: false,
+    method: "get"
 };
 
 routeHighlandExpress.endpoint = (app) => {

--- a/routes/temperature.js
+++ b/routes/temperature.js
@@ -33,7 +33,8 @@ routeTemperature.ENDPOINT = {
     getter: routeTemperature.getForecast,
     location: "",
     processor: routeTemperature.getTemperature,
-    cache: "global"
+    cache: "global",
+    method: "get"
 };
 
 routeTemperature.endpoint = (app) => {


### PR DESCRIPTION
Some endpoints do not use authentication internally, so there is no need for the app to send it to them. 

Without any sensitive data sent in the request, it then makes more sense for these endpoints to use `GET` instead of `POST` (see `README.md` for an explanation of this measure of security through obscurity).
