### PR TITLE
Fix endpoint schema

### DIFF
--- a/helpers/endpoint.js
+++ b/helpers/endpoint.js
@@ -87,7 +87,7 @@ endpoint.make = function (app, endpoint) {
 
         getData(endpoint, auth).then((data) => {
             res.setHeader("content-type", "application/json");
-            if (typeof data === "object") {
+            if (data.hasOwnProperty("data")) {
                 res.send(data);
             } else {
                 res.send({data: data});

--- a/test/regression-test.js
+++ b/test/regression-test.js
@@ -50,7 +50,8 @@ function testRoute(endpoint) {
 
             // Print only type of data
             } else {
-                console.log(`Received ${typeof data}.`);
+                console.log(`Received ${typeof data} ` +
+                            `containing keys: ${Object.keys(data)}.`);
             }
 
             done();


### PR DESCRIPTION
A faulty conditional was causing endpoints that return objects to be sent without the `{data: ...}` wrapper that the app expects. The improved conditional allows endpoints to either return an object, for example a hash with expiration like `{expiration: [date], data: 52}` or a raw data point like `52`.
