### PR TITLE
Remove app version from URLs

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,9 +8,8 @@ The GoCo Student API provides data from a variety of Gordon College websites and
 3. Install dependencies and run the server: `npm start`
 4. To make a request using [HTTPie](https://github.com/jkbrzt/httpie):
 ```bash
-http POST http://local.dev:4626/api/[version]/[endpoint] username=[username] password=[password]
+http POST http://local.dev:4626/api/[endpoint] username=[username] password=[password]
 ```
-- replace `[version]` with version number, ex: `2.5.0`
 - replace `[endpoint]` with name of endpoint, ex: `chapelcredits`
 - replace `[username]` with username, ex: `firstname.lastname`
 - replace `[password]` with Base64-encoded password
@@ -18,12 +17,12 @@ http POST http://local.dev:4626/api/[version]/[endpoint] username=[username] pas
 ### Why a Base64-encoded password?
 Good question! Base64 encoding is an easily-reversible process and therefore not secure for transmission of a password. Despite this, it provides a layer of security through obscurity by hiding the plaintext of a password when it shows up in the command line and browser local storage. The obvious alternative is to use a one-way hash to encrypt the password, but the web scraper component of the server requires the plaintext of the password in order to log in to websites on behalf of the user.
 
-Of course, obscuring the password is not all that needs to be done. To attain some semblance of security while running this server, also do the following:  
-1. Use HTTPS for all communication to and from the server.  
+Of course, obscuring the password is not all that needs to be done. To attain some semblance of security while running this server, also do the following:
+1. Use HTTPS for all communication to and from the server.
 2. Send parameters in the `POST` body, not a `GET` query string. This method of security through obscurity prevents sensitive user data from showing up in logs, where URLs containing query parameters often show up.
 
 # Endpoints
-Endpoints are defined in individual files in the `routes` directory. All of the files in the directory are automatically bootstrapped as endpoints when the app starts, except for filenames that start with an underscore, which are disabled. This is a convenient way to take an endpoint offline temporarily while working on it.  
+Endpoints are defined in individual files in the `routes` directory. All of the files in the directory are automatically bootstrapped as endpoints when the app starts, except for filenames that start with an underscore, which are disabled. This is a convenient way to take an endpoint offline temporarily while working on it.
 
 To add a new endpoint, duplicate `routes/_route-template.js` to `routes/your-route-name.js` (notice the removal of the underscore, otherwise the endpoint will remain disabled).
 
@@ -69,13 +68,13 @@ You can run the tests with `npm test`.
 The test will print each endpoint's name with its response status code, response time, and the data it returned (except when the data is an object, because it would be extremely long).
 
 ## Load Testing
-For testing of a server running the API, there is `test/load-test.js`, which you can run with `npm run loadtest`. The script uses the server URL defined in `vars.js`.  
+For testing of a server running the API, there is `test/load-test.js`, which you can run with `npm run loadtest`. The script uses the server URL defined in `vars.js`.
 
 For help, run `npm run loadtest -- --help` (note that the double `--` is necessary to pass arguments through npm to the script). The load test sends a configurable number of requests to each endpoint and reports back how long it took. Since the API depends on slow external websites, this can help you get an idea of the average response time of each endpoint.
 
 # License
-The GoCo Student API, a programmatic interface for Gordon College student data.  
-Copyright © 2016 Adam Vigneaux  
+The GoCo Student API, a programmatic interface for Gordon College student data.
+Copyright © 2016 Adam Vigneaux
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/config.js
+++ b/config.js
@@ -8,7 +8,6 @@ const EMOJI = {
 
 const config = module.exports = {};
 config.APP_NAME = "GoCoAPI";
-config.PREFIX = "/:version/";
 config.PORT = "4626";
 config.ERROR = {
     // Character measurement:

--- a/helpers/endpoint.js
+++ b/helpers/endpoint.js
@@ -1,5 +1,4 @@
 const cache = require("./cache");
-const config = require("../config");
 const utils = require("./utils");
 
 // Private:
@@ -65,7 +64,7 @@ class Endpoint {
         const method = endpoint.method || "post";
 
         // Define endpoint on app
-        app[method](config.PREFIX + endpoint.name, (req, res, next) => {
+        app[method](endpoint.name, (req, res, next) => {
 
             // Auth is only required when method is POST
             let auth = {};
@@ -98,7 +97,7 @@ class Endpoint {
         });
 
         // Define endpoint for OPTIONS preflight request
-        app.opts(config.PREFIX + endpoint.name, (req, res) => res.send(204));
+        app.opts(endpoint.name, (req, res) => res.send(204));
     }
 
     /**

--- a/test/load-test.js
+++ b/test/load-test.js
@@ -16,7 +16,6 @@ yargs.usage("$0 [args]")
     .help("help");
 
 
-const version = "2.7.0";
 const options = {
     body: {
         username: vars.test.username,
@@ -25,6 +24,9 @@ const options = {
     },
     concurrency: yargs.argv.c || yargs.argv.concurrency || 5,
     contentType: "application/json",
+    headers: {
+        "accept-version": "*"
+    },
     maxRequests: yargs.argv.r || yargs.argv.requests || 10,
     method: "POST",
     timeout: 20000 // 20 seconds
@@ -66,7 +68,7 @@ function printLoadTest(test) {
  * @param {hash} endpoint Contains name, method, and other endpoint config
  */
 function testRoute(endpoint) {
-    const url = `/${version}/${endpoint.name}`;
+    const url = `/${endpoint.name}`;
 
     options.url = vars.server.url + url;
 

--- a/test/regression-test.js
+++ b/test/regression-test.js
@@ -7,10 +7,9 @@ chai.use(require("chai-json-schema"));
 const fs = require("fs");
 const restify = require("restify");
 
-const version = "2.7.0";
 const timeout = 20000; // 20 seconds
 const client = restify.createJsonClient({
-    version: "*",
+    version: "*",    // Semver string to set the Accept-Version header to
     url: `http://localhost:${config.PORT}`,
     requestTimeout: timeout
 });
@@ -30,7 +29,7 @@ function testRoute(endpoint) {
     it("should get a 200 response", (done) => {
 
         // Remove dashes from route name and build URL
-        const url = `/${version}/${endpoint.name}`;
+        const url = `/${endpoint.name}`;
 
         // Construct request body with encoded password
         const body = {


### PR DESCRIPTION
See #6 Add true API versioning.

This pull request removes the `/:version/` component of the API URLs for all the endpoints. This version represented the version of the app that was requesting the data, which is backward in terms of API versioning schemes.
